### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,28 +1,28 @@
 {
-    "name": "Tags to image URLs",
-    "type": "app",
-    "categories": [
-        "images",
-        "export",
-        "annotation transformation",
-        "data operations"
+  "name": "Tags to image URLs",
+  "type": "app",
+  "categories": [
+    "images",
+    "export",
+    "annotation transformation",
+    "data operations"
+  ],
+  "description": "Saves tag to images mapping to a json file",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "modal_template_state": {
+    "saveMode": "both"
+  },
+  "task_location": "workspace_tasks",
+  "icon": "https://i.imgur.com/ijjjtx7.png",
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "target": [
+      "images_project"
     ],
-    "description": "Saves tag to images mapping to a json file",
-    "docker_image": "supervisely/import-export:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "modal_template": "src/modal.html",
-    "modal_template_state": {
-        "saveMode": "both"
-    },
-    "task_location": "workspace_tasks",
-    "icon": "https://i.imgur.com/ijjjtx7.png",
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "target": [
-            "images_project"
-        ],
-        "context_root": "Report"
-    },
-    "poster": "https://user-images.githubusercontent.com/48245050/182636117-e765e8ec-d073-404a-8068-f600eaefdcf3.png"
+    "context_root": "Report"
+  },
+  "poster": "https://user-images.githubusercontent.com/48245050/182636117-e765e8ec-d073-404a-8068-f600eaefdcf3.png"
 }

--- a/config.json
+++ b/config.json
@@ -8,8 +8,8 @@
         "data operations"
     ],
     "description": "Saves tag to images mapping to a json file",
-    "docker_image": "supervisely/import-export:6.73.530",
-    "instance_version": "6.15.40",
+    "docker_image": "supervisely/import-export:6.73.564",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import os
-import supervisely_lib as sly
-from supervisely_lib.annotation.annotation import TagCollection
-from supervisely_lib.io.json import dump_json_file
+import supervisely as sly
+from supervisely.annotation.annotation import TagCollection
+from supervisely.io.json import dump_json_file
 
 
 my_app = sly.AppService()


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
